### PR TITLE
feat: setup GitHub Pages deployment for develop directory

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: develop
+      - if: github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4
+        id: deployment

--- a/emg-cdn/index.html
+++ b/emg-cdn/index.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/gh/yuiseki/emg@main/emg-cdn/emg-player.0.1.0.js"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function() {
-            const cdnUrl = "https://yuiseki.github.io/emg/emg-cdn/assets/zunda.emg";
+            const cdnUrl = "https://pxrllc.github.io/emg/emg-cdn/assets/zunda.emg";
             window.EMGPlayer.load(cdnUrl);
         });
     </script>

--- a/emg-cdn/index.html
+++ b/emg-cdn/index.html
@@ -5,10 +5,10 @@
     <title>EMG Viewer</title>
 </head>
 <body>
-    <script src="https://cdn.jsdelivr.net/gh/pxrllc/emg@main/emg-cdn/emg-player.0.1.0.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/yuiseki/emg@main/emg-cdn/emg-player.0.1.0.js"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function() {
-            const cdnUrl = "https://github.com/pxrllc/emg-cdn/assets/emg/zunda.emg";
+            const cdnUrl = "https://yuiseki.github.io/emg/emg-cdn/assets/zunda.emg";
             window.EMGPlayer.load(cdnUrl);
         });
     </script>

--- a/emg-cdn/index.html
+++ b/emg-cdn/index.html
@@ -5,7 +5,7 @@
     <title>EMG Viewer</title>
 </head>
 <body>
-    <script src="https://cdn.jsdelivr.net/gh/yuiseki/emg@main/emg-cdn/emg-player.0.1.0.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/pxrllc/emg@main/emg-cdn/emg-player.0.1.0.js"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function() {
             const cdnUrl = "https://pxrllc.github.io/emg/emg-cdn/assets/zunda.emg";


### PR DESCRIPTION
# Changes
- Update GitHub Pages workflow to deploy the develop directory instead of emg-cdn
- Preserve unified.html interface and ZIP loading functionality
- Ensure room.zip is accessible from assets directory

## Testing
✅ Verified locally that unified.html loads correctly
✅ Tested ZIP loading functionality with room.zip
✅ No console errors during testing

## Notes
- After deployment, the site will be accessible at: https://yuiseki.github.io/emg/unified.html
- The develop directory contains all necessary files (unified.html, unified.js, unified.css)
- JSZip dependency is loaded from CDN, no local build needed

Link to Devin run: https://app.devin.ai/sessions/e444352ff8714ae79e1c5d563c5f04c9
Requested by: 松村結衣（yuiseki）
