### PR TITLE
Update EMG-lite specs for extended state support

### DIFF
--- a/emg-lite/ISSUES.md
+++ b/emg-lite/ISSUES.md
@@ -33,3 +33,25 @@ Labels: `emg-lite`, `avatar`, `integration`
 - **内容**:
   - 外部開発者向け（将来用）のドキュメント整備
 - **Status**: Todo
+
+### 5. [emg-lite] 拡張ステート対応のプレイヤー実装
+- **タイトル**: sleep/blinking/mouthShape/overlays のプレイヤー実装
+- **内容**:
+  - `EMGLiteState` に追加された `sleep`, `blinking`, `mouthShape`, `overlays` を Viewer/Adapter に反映
+  - `mouthShape_*` スロットの解決と `speaking` フォールバック
+  - オーバーレイ辞書の描画順合成
+- **Status**: Todo
+
+### 6. [emg-lite] 可変スロットと未知キーの安全な無視実装
+- **タイトル**: AssetGroup の拡張スロット対応
+- **内容**:
+  - 5スロット以外の任意キーを安全に無視するガード
+  - 実装済みアダプタで未知キーがあってもクラッシュしないことの確認
+- **Status**: Todo
+
+### 7. [emg-lite] schemaVersion の解釈と互換ポリシー実装
+- **タイトル**: schemaVersion を用いた互換管理
+- **内容**:
+  - `model.json` の `schemaVersion` を読み取り、未知フィールドを無視する後方互換ポリシーを実装
+  - バージョンミスマッチ時の警告表示（ロギング）を追加
+- **Status**: Todo

--- a/emg-lite/README.md
+++ b/emg-lite/README.md
@@ -14,7 +14,18 @@ EMG-lite (Expression / Motion / Gesture - lite) は、アバターの状態を�
 詳細は `types.ts` を参照してください。
 
 ## 拡張
-将来的にユーザー定義のステートや、より詳細な強度パラメータを追加可能です。
+将来的にユーザー定義のステートや、より詳細な強度パラメータを追加可能です。  
+コアステートとして以下を定義します（必須以外はオプショナル扱い）。
+
+- `emotion` (必須): 表情
+- `activity` (必須): 行動・ポーズ
+- `speaking` (必須): 発話真偽
+- `intensity` (必須): 表現の強度ヒント
+- `sleep` (任意): 睡眠/休止状態。`isSleep` スロットを優先利用
+- `blinking` (任意): 瞬き状態。`eyesClosed` スロットを優先利用
+- `mouthShape` (任意): 口形状/音素（`a/i/u/e/o/rest` など）。未指定時は `speaking` にフォールバック
+- `overlays` (任意): 汗・傷・エフェクト等の一時オーバーレイ ID 配列（後方ほど手前に重ねる）
+- `context` (任意): 実装依存メタデータ（例: 伺かサーフィス番号）を格納し、アダプタ層で解決
 
 ## スコープと推奨される使用法
 EMG-Liteにおける「Status（ステート）」は、主に**表情差分や軽微なジェスチャーの変化**を表現することを想定しています。
@@ -46,10 +57,9 @@ filename.emgl (ZIP)
 ## 詳細ドキュメント (Specifications)
 より詳細な仕様については、以下のドキュメントを参照してください。
 
--   **[.emgl ファイル仕様 / .emgl Specification](./tools/emg-viewer/docs/emgl_spec.md)**
+-   **[.emgl ファイル仕様 / .emgl Specification](./tools/emg-viewer/docs/emgl_spec.md)**（`schemaVersion` による互換方針を含む）
     -   コンテナフォーマットの詳細仕様、ファイル構成、パス解決ルールなど。
 -   **[モデル仕様 / Model Specification](./tools/emg-viewer/docs/model_spec.md)**
-    -   `model.json` の構造、マッピングロジック（5スロットシステム）、画像設定など。
+    -   `model.json` の構造、マッピングロジック（5スロットシステム）、可変スロット/オーバーレイ拡張など。
 -   **[プレイヤー仕様 / Player Specification](./tools/emg-viewer/docs/player_spec.md)**
-    -   EMGステート定義、デモモード、リップシンク挙動などのViewer仕様。
-
+    -   EMGステート定義、デモモード、リップシンク挙動、拡張ステートのフォールバックルールなど。

--- a/emg-lite/tools/emg-viewer/docs/model_spec.md
+++ b/emg-lite/tools/emg-viewer/docs/model_spec.md
@@ -8,6 +8,7 @@ The model is defined by a single JSON object with the following top-level proper
 
 ```json
 {
+  "schemaVersion": 1,          // [Optional] Schema/compatibility version
   "width": 1000,                // [Optional] Base Width (Canvas Size)
   "height": 1000,               // [Optional] Base Height (Canvas Size)
   "license": "CC0",             // [Optional] License Information
@@ -41,6 +42,7 @@ The model is defined by a single JSON object with the following top-level proper
 -   **Key Format**: `[Activity].[Emotion]` (e.g., `idle.neutral`, `talking.joy`)
     -   **Activity**: Top-level state (e.g., `idle`, `pointing`).
     -   **Emotion**: Facial expression (e.g., `neutral`, `happy`, `sad`).
+    -   Implementations MAY ignore unknown activities/emotions; prefer a fallback entry like `idle.neutral`.
 
 #### AssetGroup Structure (5-Slot System)
 Each mapping key points to an object defining up to 5 image slots for granular control:
@@ -70,6 +72,15 @@ Each mapping key points to an object defining up to 5 image slots for granular c
     4.  **Defined Idle**: If `!speaking` AND `mouthClosed` defined -> Use `mouthClosed`.
     5.  **Fallback**: Use `base`.
 
+#### Extended Slots (Optional, Backward-Compatible)
+-   AssetGroup MAY contain additional slots beyond the 5 standard ones (e.g., `handPose`, `accessory`, `background`).
+-   Unknown slot keys MUST be ignored safely by players that do not implement them.
+-   A slot MAY carry viseme-specific filenames (e.g., `mouthShape_a`, `mouthShape_i`, ...). If none match, the standard `mouthOpen/mouthClosed` fallback applies.
+
+#### Overlays
+-   Each AssetGroup MAY define an `overlays` dictionary whose keys correspond to overlay IDs (strings) and values are filenames.
+-   When `state.overlays` is present, the player resolves overlays in order and stacks them on top of the resolved base slot.
+
 ### 3. Image Configuration (`imageConfig`)
 Allows disabling specific automatic behaviors for certain slots.
 
@@ -96,6 +107,7 @@ Allows disabling specific automatic behaviors for certain slots.
 
 ```json
 {
+  "schemaVersion": 1,          // [任意] 互換性判定のためのスキーマバージョン
   "assetsRoot": "./",           // アセットディレクトリのパス (JSONからの相対パス、または絶対パス)
   "mapping": { ... }           // 状態(State)とアセット(Assets)のマッピング辞書
 }
@@ -127,6 +139,7 @@ Allows disabling specific automatic behaviors for certain slots.
 -   **キー形式**: `[Activity].[Emotion]` (例: `idle.neutral`, `talking.joy`)
     -   **Activity**: 行動・動作 (例: `idle`=待機, `pointing`=指差し)。
     -   **Emotion**: 表情・感情 (例: `neutral`=通常, `happy`=笑顔, `sad`=悲しみ)。
+    -   未知の activity/emotion は無視される可能性があるため、`idle.neutral` などのフォールバックを推奨。
 
 #### アセットグループ構造 (5スロットシステム)
 各マッピングキーは、きめ細かな制御のために最大5つの画像スロットを定義するオブジェクトを指します。
@@ -155,6 +168,14 @@ Allows disabling specific automatic behaviors for certain slots.
     3.  **発話 (Speaking)**: `speaking` で、`mouthOpen` が定義されている場合 -> これを使用。
     4.  **待機指定 (Defined Idle)**: `!speaking` で、`mouthClosed` が定義されている場合 -> これを使用。
     5.  **基本 (Fallback)**: 上記以外は `base` を使用。
+
+#### 拡張スロット（後方互換のオプション）
+-   5スロット以外の任意キー（例: `handPose`, `accessory`, `background`）を追加可能。未対応プレイヤーは無視する。
+-   音素別の口形状 (`mouthShape_a`, `mouthShape_i` など) を持たせてもよい。該当が無い場合は従来の `mouthOpen/mouthClosed` へフォールバック。
+
+#### オーバーレイ
+-   各 AssetGroup は `overlays` 辞書を持てる。キーはオーバーレイID（文字列）、値はファイル名。
+-   `state.overlays` が与えられた場合、その順序でオーバーレイを解決し、基底スロットの上に合成する。
 
 ### 3. 画像設定 (`imageConfig`)
 特定のスロットに対して、自動的な挙動（リップシンクや瞬き）を無効化するために使用します。

--- a/emg-lite/tools/emg-viewer/docs/player_spec.md
+++ b/emg-lite/tools/emg-viewer/docs/player_spec.md
@@ -7,12 +7,20 @@ The viewer is driven by the `EMGLiteState` object:
 
 ```typescript
 interface EMGLiteState {
-    emotion: string;    // e.g., 'neutral', 'joy'
-    activity: string;   // e.g., 'idle', 'wave'
-    speaking: boolean;  // true = mouth open, false = mouth closed
-    intensity: number;  // 0.0 to 1.0 (Reserved for future interpolation)
+    emotion: string;       // e.g., 'neutral', 'joy'
+    activity: string;      // e.g., 'idle', 'wave'
+    speaking: boolean;     // true = mouth open, false = mouth closed
+    intensity: number;     // 0.0 to 1.0 (strength hint)
+    sleep?: boolean;       // prefer sleep mapping when true
+    blinking?: boolean;    // prefer eyesClosed when true
+    mouthShape?: string;   // e.g., 'a' | 'i' | 'u' | 'e' | 'o' | 'rest'
+    overlays?: string[];   // overlay IDs in draw order (later = top)
+    context?: Record<string, unknown>; // optional metadata for adapters
 }
 ```
+
+> Fallback rule: if `mouthShape` is undefined, lip sync uses `speaking` boolean;
+> if `sleep` or `blinking` are undefined, they are treated as `false`.
 
 ## Features
 
@@ -39,6 +47,7 @@ interface EMGLiteState {
 The player resolves the final image path by combining:
 1.  **Assets Root**: Defined in the loaded JSON Model.
 2.  **Resolved Slot**: The filename chosen by the 5-Slot Priority Logic (see [Model Spec](./model_spec.md)).
+3.  **Optional Overlays**: Additional overlay filenames resolved after base slots.
 
 Example: `assetsRoot: "/assets/char/"` + `mouthOpen: "talk.png"` -> Result: `/assets/char/talk.png`.
 
@@ -67,10 +76,16 @@ interface EMGLiteState {
     emotion: string;    // 感情 (例: 'neutral', 'joy')
     activity: string;   // 行動 (例: 'idle', 'wave')
     speaking: boolean;  // 発話状態 (true = 開口, false = 閉口)
-    sleep: boolean;     // 睡眠状態 (true = 睡眠中)
-    intensity: number;  // 強度 0.0 ～ 1.0 (将来的な補間用に予約)
+    intensity: number;  // 強度 0.0 ～ 1.0 (表現の強さヒント)
+    sleep?: boolean;    // 睡眠状態 (true = 睡眠中)
+    blinking?: boolean; // 瞬き状態 (true = 閉眼)
+    mouthShape?: string;// 口形状/音素（例: 'a' | 'i' | 'u' | 'e' | 'o' | 'rest'）
+    overlays?: string[];// オーバーレイID（後方ほど手前に重ねる）
+    context?: Record<string, unknown>; // 任意メタデータ（アダプタで解決）
 }
 ```
+
+> フォールバック: `mouthShape` 未指定時は `speaking` 真偽で口差分を決める。`sleep` / `blinking` 未指定時は `false` とみなす。
 
 ## 機能
 

--- a/emg-lite/types.ts
+++ b/emg-lite/types.ts
@@ -23,9 +23,41 @@ export interface EMGLiteState {
 
   /**
    * 感情や動作の強度 (0.0 - 1.0)
-   * 表現の深さを制御するために予約
+   * 「どのくらい強く表情/ポーズを出すか」のヒント値
+   * 0.0 は静止、1.0 は最大の強度を想定
    */
   intensity: number;
+
+  /**
+   * 睡眠/待機状態
+   * sleep=true の場合、sleep スロットを優先的に使用する
+   */
+  sleep?: boolean;
+
+  /**
+   * 瞬き状態
+   * blinking=true の場合、eyesClosed スロットを優先的に使用する
+   */
+  blinking?: boolean;
+
+  /**
+   * 口形状 (音素やviseme名)
+   * 例: 'a' | 'i' | 'u' | 'e' | 'o' | 'rest'
+   * 未指定の場合は speaking の真偽値でフォールバックする
+   */
+  mouthShape?: string;
+
+  /**
+   * 一時的なオーバーレイ差分（汗・傷・エフェクト等）の識別子
+   * 表示する順序で配列を並べる（後ろの要素ほど上に重ねる）
+   */
+  overlays?: string[];
+
+  /**
+   * 任意メタデータ（実装依存）。伺かサーフィス番号などを格納し、
+   * アダプタ層で activity/emotion やスロットにマッピングさせる用途を想定
+   */
+  context?: Record<string, unknown>;
 }
 
 /**
@@ -36,4 +68,9 @@ export const INITIAL_EMG_LITE_STATE: EMGLiteState = {
   activity: 'idle',
   speaking: false,
   intensity: 0.0,
+  sleep: false,
+  blinking: false,
+  mouthShape: undefined,
+  overlays: [],
+  context: {},
 };


### PR DESCRIPTION
## Summary
- document extended EMG-lite state (sleep, blinking, mouthShape, overlays, context) and fallback rules
- expand model/player specs with optional overlays, flexible slots, schemaVersion guidance, and adapter metadata
- add follow-up issues to implement new runtime behaviors and compatibility handling

## Testing
- not run (docs/issue updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc528dba48326ba4e6067778474a4)